### PR TITLE
Add matching history

### DIFF
--- a/backend/gateway-service/src/modules/match/redis.service.ts
+++ b/backend/gateway-service/src/modules/match/redis.service.ts
@@ -26,10 +26,16 @@ export class RedisMatchService {
     // Listen for published messages on the channel
     this.redisSubscriber.on('message', (channel, message) => {
       if (channel === 'matchChannel') {
-        const matchedUsers = JSON.parse(message);
-        callback(matchedUsers);
-      }
-    });
+        const parsedMessage = JSON.parse(message);
+        if (
+          parsedMessage.matchId &&
+          Array.isArray(parsedMessage.matchedUserIds)
+        ) {
+          callback({
+            matchId: parsedMessage.matchId,
+            matchedUserIds: parsedMessage.matchedUserIds,
+          });
+    }}});
   }
 
   subscribeToTimeoutEvents(callback: (matchedUsers: any) => void): void {

--- a/backend/matching-service/package-lock.json
+++ b/backend/matching-service/package-lock.json
@@ -13,11 +13,13 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/microservices": "^10.4.4",
+        "@nestjs/mongoose": "^10.1.0",
         "@nestjs/platform-express": "^10.0.0",
         "bull": "^4.16.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "dotenv": "^16.4.5",
+        "mongoose": "^8.7.2",
         "redis": "^4.7.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1"
@@ -1566,6 +1568,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -1920,6 +1930,17 @@
         "nats": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/mongoose": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mongoose/-/mongoose-10.1.0.tgz",
+      "integrity": "sha512-1ExAnZUfh2QffEaGjqYGgVPy/sYBQCVLCLqVgkcClKx/BCd0QNgND8MB70lwyobp3nm/+nbGQqBpu9F3/hgOCw==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "mongoose": "^6.0.2 || ^7.0.0 || ^8.0.0",
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/@nestjs/platform-express": {
@@ -2408,6 +2429,19 @@
       "version": "13.12.2",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz",
       "integrity": "sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -3277,6 +3311,14 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.9.0.tgz",
+      "integrity": "sha512-X9hJeyeM0//Fus+0pc5dSUMhhrrmWwQUtdavaQeF3Ta6m69matZkGWV/MrBcnwUeLC8W9kwwc2hfkZgUuCX3Ig==",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer": {
@@ -6339,6 +6381,14 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6536,6 +6586,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -6672,6 +6727,131 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.9.0.tgz",
+      "integrity": "sha512-UMopBVx1LmEUbW/QE0Hw18u583PEDVQmUmVzzBRH0o/xtE9DBRA5ZYLOjpLIa03i8FXjzvQECJcqoMvCXftTUA==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.7.2.tgz",
+      "integrity": "sha512-Ok4VzMds9p5G3ZSUhmvBm1GdxanbzhS29jpSn02SPj+IXEVFnIdfwAlHHXWkyNscZKlcn8GuMi68FH++jo0flg==",
+      "dependencies": {
+        "bson": "^6.7.0",
+        "kareem": "2.6.3",
+        "mongodb": "6.9.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -7283,7 +7463,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7876,6 +8055,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7929,6 +8113,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {

--- a/backend/matching-service/package.json
+++ b/backend/matching-service/package.json
@@ -24,11 +24,13 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/microservices": "^10.4.4",
+    "@nestjs/mongoose": "^10.1.0",
     "@nestjs/platform-express": "^10.0.0",
     "bull": "^4.16.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "dotenv": "^16.4.5",
+    "mongoose": "^8.7.2",
     "redis": "^4.7.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"

--- a/backend/matching-service/src/app.controller.ts
+++ b/backend/matching-service/src/app.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
-import { MessagePattern, Payload } from '@nestjs/microservices';
+import { EventPattern, MessagePattern, Payload } from '@nestjs/microservices';
 import { MatchRequestDto } from './dto';
 
 @Controller()
@@ -15,5 +15,20 @@ export class AppController {
   @MessagePattern('match-cancel')
   async handleMatchCancel(@Payload() data: { userId: string }) {
     return this.appService.cancelMatch(data.userId);
+  }
+
+  @EventPattern('match-confirmed')
+  async handleMatchConfirmed(@Payload() data: { matchId: string, sessionId: string}) {
+    return this.appService.matchConfirmed(data.matchId, data.sessionId);
+  }
+
+  @EventPattern('match-declined')
+  async handleMatchDeclined(@Payload() data: { matchId: string}) {
+    return this.appService.matchDeclined(data.matchId);
+  }
+
+  @MessagePattern('match-history')
+  async handleMatchHistoryBySessionId(@Payload() data: { sessionId: string }) {
+    return this.appService.getMatchHistory(data.sessionId);
   }
 }

--- a/backend/matching-service/src/app.module.ts
+++ b/backend/matching-service/src/app.module.ts
@@ -6,9 +6,18 @@ import { ClientsModule } from '@nestjs/microservices';
 import { MatchWorkerService } from './match-worker.service';
 import { RedisService } from './redis.service';
 import { config } from 'src/configs';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MatchHistorySchema } from './schema/match-history.schema';
 
 @Module({
   imports: [
+    MongooseModule.forRoot(config.mongo.connectionString),
+    MongooseModule.forFeature([
+      {
+        name: 'MatchHistory',
+        schema: MatchHistorySchema,
+      },
+    ]),
     BullModule.forRoot({
       redis: {
         host: config.redis.host,

--- a/backend/matching-service/src/app.service.ts
+++ b/backend/matching-service/src/app.service.ts
@@ -2,10 +2,17 @@ import { Injectable } from '@nestjs/common';
 import { MatchRequestDto } from './dto/match-request.dto';
 import { RedisService } from './redis.service';
 import { MatchResponse } from './interfaces';
+import { InjectModel } from '@nestjs/mongoose';
+import { MatchHistory } from './schema/match-history.schema';
+import { Model, Types } from 'mongoose';
 
 @Injectable()
 export class AppService {
-  constructor(private redisService: RedisService) {}
+  constructor(
+    private redisService: RedisService,
+    @InjectModel('MatchHistory')
+    private readonly matchHistoryModel: Model<MatchHistory>,
+  ) {}
 
   // Add user to the Redis pool
   async requestMatch(data: MatchRequestDto): Promise<MatchResponse> {
@@ -15,5 +22,49 @@ export class AppService {
   // Remove user from the Redis pool
   async cancelMatch(userId: string): Promise<MatchResponse> {
     return this.redisService.removeUsersFromPool([userId]);
+  }
+
+  // Handle match confirmed event
+  async matchConfirmed(matchId: string, sessionId: string): Promise<void> {
+    const match = await this.findMatchByMatchId(matchId);
+    
+    if (!match) {
+      throw new Error('Match not found');
+    }
+    match.sessionId = sessionId;
+    match.status = 'confirmed';
+    await match.save();
+  }
+
+  // Handle match declined event
+  async matchDeclined(matchId: string): Promise<void> {
+    const match = await this.findMatchByMatchId(matchId);
+    
+    if (!match) {
+      throw new Error('Match not found');
+    }
+
+    match.status = 'cancelled';
+    await match.save();
+  }
+
+  async createMatchHistoryDocument(data: {userIds: string[], topicPreference: string[], difficultyPreference: string}): Promise<MatchHistory> {
+    const match = new this.matchHistoryModel({
+      userIds: data.userIds,
+      topicPreference: data.topicPreference,
+      difficultyPreference: data.difficultyPreference,
+      status: 'pending',
+    });
+    return match.save();
+  }
+
+  async getMatchHistory(sessionId: string): Promise<MatchHistory> {
+    return this.matchHistoryModel.findOne({ sessionId }).exec();
+  }
+
+
+  private async findMatchByMatchId(matchId: string): Promise<MatchHistory> {
+    const objectId = new Types.ObjectId(matchId);
+    return this.matchHistoryModel.findById(objectId).exec();
   }
 }

--- a/backend/matching-service/src/match-worker.service.ts
+++ b/backend/matching-service/src/match-worker.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { MatchRequestDto } from './dto';
 import { RedisService } from './redis.service';
-import { PriorityQueue } from './helper/priority-queue';
+import { AppService } from './app.service';
 
 @Injectable()
 export class MatchWorkerService {
-  constructor(private readonly redisService: RedisService) {}
+  constructor(private readonly redisService: RedisService, private readonly appService: AppService) {}
 
   private INTERNAL_TIMEOUT = 300000; // 5 minutes
   private CHECK_INTERVAL = 5000; // 5 seconds
@@ -38,11 +38,14 @@ export class MatchWorkerService {
         const matches = this.rankUsers(activeUsers);
         const bestMatch = matches[0];
 
+        const newMatchDocument = await this.appService.createMatchHistoryDocument({
+          userIds: [bestMatch.user1.userId, bestMatch.user2.userId],
+          topicPreference: bestMatch.generatedTopic,
+          difficultyPreference: bestMatch.generatedDifficulty,
+        });
+
         // Notify the gateway via Redis Pub/Sub
-        await this.notifyGateway([
-          bestMatch.user1.userId,
-          bestMatch.user2.userId,
-        ]);
+        await this.notifyGateway({matchId: newMatchDocument._id.toString(), matchedUserIds: [bestMatch.user1.userId, bestMatch.user2.userId]});
 
         // Remove the matched users from the Redis pool
         await this.redisService.removeUsersFromPool([
@@ -58,12 +61,13 @@ export class MatchWorkerService {
   // Ranking logic for matches
   private rankUsers(
     users: MatchRequestDto[],
-  ): { user1: MatchRequestDto; user2: MatchRequestDto; score: number }[] {
+  ): { user1: MatchRequestDto; user2: MatchRequestDto; score: number, generatedTopic: string[]; generatedDifficulty: string }[] {
     const matches = [];
     for (let i = 0; i < users.length; i++) {
       for (let j = i + 1; j < users.length; j++) {
+        const { topics, difficulty } = this.generateMatchAttributes(users[i], users[j]);
         const score = this.calculateScore(users[i], users[j]);
-        matches.push({ user1: users[i], user2: users[j], score });
+        matches.push({ user1: users[i], user2: users[j], score, generatedTopic: topics, generatedDifficulty: difficulty });
       }
     }
     return matches.sort((a, b) => b.score - a.score);
@@ -84,8 +88,74 @@ export class MatchWorkerService {
     return score;
   }
 
-  async notifyGateway(matchedUserIds: string[]) {
-    await this.redisService.publishMatchedUsers(matchedUserIds);
+  private generateMatchAttributes(
+    user1: MatchRequestDto,
+    user2: MatchRequestDto,
+  ): { topics: string[]; difficulty: string } {
+    // Find common topics between the two users
+    const matchingTopics = user1.selectedTopic.filter((topic) =>
+      user2.selectedTopic.includes(topic),
+    );
+
+    // If common topics exist, use them, otherwise, choose a fallback strategy
+    const generatedTopics = matchingTopics.length > 0
+      ? matchingTopics
+      : this.selectAlternativeTopics();
+
+    // Generate a difficulty based on both users' selected difficulty levels
+    const generatedDifficulty = this.inferDifficulty(user1.selectedDifficulty, user2.selectedDifficulty);
+
+    return { topics: generatedTopics, difficulty: generatedDifficulty };
+  }
+
+  // TODO: Implement a more sophisticated algorithm to generate alternative topics (e.g considering user topic preferences selected during onboarding)
+  private selectAlternativeTopics(): string[] {
+    const QUESTION_CATEGORIES = [
+      "Array",
+      "Binary Search",
+      "Divide and Conquer",
+      "Dynamic Programming",
+      "Hash Table",
+      "Linked List",
+      "Math",
+      "Sliding Window",
+      "Stack",
+      "String",
+      "Two Sum"
+    ]
+    const NUM_QUESTIONS_TO_GENERATE = 2;
+    // Simply generate 2 random topics for now
+    const generatedTopics = [];
+    while (generatedTopics.length < NUM_QUESTIONS_TO_GENERATE) {
+      const randomIndex = Math.floor(Math.random() * QUESTION_CATEGORIES.length);
+      const randomTopic = QUESTION_CATEGORIES[randomIndex];
+      if (!generatedTopics.includes(randomTopic)) {
+        generatedTopics.push(randomTopic);
+      }
+    }
+    return generatedTopics;
+  }
+
+
+  private inferDifficulty(
+    difficulty1: string,
+    difficulty2: string,
+  ): string {
+    // Case 1: Both users have the same difficulty
+    if (difficulty1 === difficulty2) {
+      return difficulty1;
+    }
+
+    // Case 2: Both users have different difficulties, return the median difficulty
+    const difficulties = ["Easy", "Medium", "Hard"];
+    const index1 = difficulties.indexOf(difficulty1);
+    const index2 = difficulties.indexOf(difficulty2);
+
+    return difficulties[Math.floor((index1 + index2) / 2)];
+  }
+
+  async notifyGateway(data: {matchId: string, matchedUserIds: string[]}) {
+    await this.redisService.publishMatchedUsers(data.matchId, data.matchedUserIds);
   }
 
   async notifyGatewayTimeout(userIds: string[]) {

--- a/backend/matching-service/src/redis.service.ts
+++ b/backend/matching-service/src/redis.service.ts
@@ -98,10 +98,14 @@ export class RedisService {
     }
   }
 
-  async publishMatchedUsers(matchedUserIds: string[]): Promise<void> {
+  async publishMatchedUsers(matchId: string, matchedUserIds: string[]): Promise<void> {
+    const message = {
+      matchId: matchId,
+      matchedUserIds: matchedUserIds,
+    };
     await this.redisPublisher.publish(
       'matchChannel',
-      JSON.stringify(matchedUserIds),
+      JSON.stringify(message),
     );
   }
 

--- a/backend/matching-service/src/schema/match-history.schema.ts
+++ b/backend/matching-service/src/schema/match-history.schema.ts
@@ -1,0 +1,22 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ collection: 'match-history', versionKey: false, timestamps: true })
+export class MatchHistory extends Document {
+  @Prop({ required: false, default: '' })
+  sessionId: string;
+
+  @Prop({ required: true, default: [] })
+  userIds: string[];
+
+  @Prop({ required: true, default: [] })
+  topicPreference: string[];
+
+  @Prop({ required: true, enum: ['Easy', 'Medium', 'Hard'], default: 'Easy' })
+  difficultyPreference: string;
+
+  @Prop({ required: true, enum: ['pending', 'confirmed', 'cancelled'], default: 'pending' })
+  status: string;
+}
+
+export const MatchHistorySchema = SchemaFactory.createForClass(MatchHistory);


### PR DESCRIPTION
# Pull Request Title:
Add `match-history` Collection for Storing User Preferences and Match States

## Summary:
This PR introduces a new `match-history` collection to the database and modifies the matching logic to store user preferences (`topic` and `difficulty`) alongside the match state (`pending`, `accepted`, or `declined`). The goal is to create a more cohesive flow between the matching service and the collaboration service, enabling future enhancements such as question selection/voting.

## Changes Made:
1. **Created `match-history` Collection**:
   - A new database collection named `match-history` was added to store information about user matches. The stored information includes user preferences such as `topic` and `difficulty`, along with the current state of the match.
   - **Possible match states**: `pending` (both users haven't confirmed yet), `accepted` (both users have confirmed the match), and `declined` (one or both users declined the match).

2. **Updated Match Logic**:
   - When a match is found, a match history entry is created with the state set to `pending`. The entry also captures user preferences (`topic` and `difficulty`) to preserve context.
   - If both users accept the match, the state of the match history entry is updated to `accepted`. If a user declines, the state is marked as `declined`.
   - User preferences (`topic` and `difficulty`) are stored with each match history entry, ensuring that these preferences are easily accessible and centralized.

3. **Separation of Concerns and Future Flexibility**:
   - By storing the user preferences in a centralized match history, the collaboration service now has access to these preferences without relying on the matching service.
   - The collaboration service can directly reference match history to determine the context for fetching and filtering questions, improving overall architecture and separation of concerns.

## Intentions for Changes:
1. **Collaboration Service Awareness**:
   - Currently, the collaboration service is not aware of user preferences (`topic` and `difficulty`) since these are handled exclusively within the matching service. This can lead to limited flexibility and cohesion in the workflow. By centralizing these preferences in the match history, the collaboration service can easily access them to determine which questions to offer.
   
2. **Enhanced Flexibility and Workflow**:
   - Storing the user preferences allows us to implement a potential feature where users can vote or select specific questions before starting the collaboration session. This introduces a more dynamic experience and gives users control over the questions they’ll tackle.
   - The likely workflow for question selection will be:
     - **Get user preferences**: Retrieve the stored preferences (topic and difficulty) from the match history.
     - **Fetch questions based on preferences**: Use the preferences to query a set of potential questions.
     - **Vote/Select questions**: Allow both users to vote or choose the questions they prefer.
     - **Start the collaboration session**: Once questions are selected, pass them as part of the collaboration session initialization.



## Next Steps:
- Introduce endpoints in the collaboration service to support question voting and selection, leveraging the stored match history.
- Implement a caching layer if necessary to optimize frequent reads of match history entries, especially for large-scale sessions.

